### PR TITLE
Changed nodemon argument from --debug to --inspect

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "start": "node src/server.js",
     "ssl": "npm start --node-red-template-embedded:http_port=1882 --node-red-template-embedded:use_https=true",
-    "debug": "cross-env NODE_ENV=development \"nodemon --config .nodemonrc.json --debug src/server.js\"",
+    "debug": "cross-env NODE_ENV=development \"nodemon --config .nodemonrc.json --inspect src/server.js\"",
     "admin": "node-red-admin",
     "adminauth": "node -e \"console.log(require('bcryptjs').hashSync(process.argv[1], 8));\"",
     "selfsigned": "node -e \"var pems = require('selfsigned').generate([{ name: 'commonName', value: process.argv[1] }], { days: 365 }); var fs = require('fs'); fs.writeFileSync('server.key', pems.private); fs.writeFileSync('server.crt', pems.cert); console.log('Updated server.key|crt for CN', process.argv[1]);\""


### PR DESCRIPTION
I guess the argument was renamed sometime in the past.